### PR TITLE
fix: 修正1.21.1的附魔支持。

### DIFF
--- a/src/generated/resources/data/minecraft/tags/item/enchantable/durability.json
+++ b/src/generated/resources/data/minecraft/tags/item/enchantable/durability.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "touhou_little_maid:hakurei_gohei",
+    "touhou_little_maid:sanae_gohei",
+    "touhou_little_maid:ultramarine_orb_elixir"
+  ]
+}

--- a/src/generated/resources/data/touhou_little_maid/tags/enchantment/bauble_incompatible.json
+++ b/src/generated/resources/data/touhou_little_maid/tags/enchantment/bauble_incompatible.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:mending"
+  ]
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/datagen/DataGenerator.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/datagen/DataGenerator.java
@@ -51,6 +51,7 @@ public class DataGenerator {
                 .addProvider(packOutput -> new TagBlock(packOutput, registries, TouhouLittleMaid.MOD_ID, existingFileHelper));
         vanillaPack.addProvider(
                 packOutput -> new TagItem(packOutput, registries, blockTagsProvider.contentsGetter(), TouhouLittleMaid.MOD_ID, existingFileHelper));
+        vanillaPack.addProvider(packOutput -> new TagEnchantment(packOutput, registries, TouhouLittleMaid.MOD_ID, existingFileHelper));
         generator.addProvider(event.includeServer(), new DamageTypeGenerator(pack, event.getLookupProvider(), event.getExistingFileHelper()));
         generator.addProvider(event.includeServer(), new EntityTypeGenerator(pack, event.getLookupProvider(), event.getExistingFileHelper()));
         generator.addProvider(event.includeServer(), new TagRecipeSerializer(pack, event.getLookupProvider(), event.getExistingFileHelper()));

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/datagen/tag/TagEnchantment.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/datagen/tag/TagEnchantment.java
@@ -1,19 +1,29 @@
 package com.github.tartaricacid.touhoulittlemaid.datagen.tag;
 
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.tags.EnchantmentTagsProvider;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.Enchantments;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.concurrent.CompletableFuture;
 
+import static com.github.tartaricacid.touhoulittlemaid.util.ResourceLocationUtil.getResourceLocation;
+
 public class TagEnchantment extends EnchantmentTagsProvider {
+    public static final TagKey<Enchantment> BAUBLE_INCOMPATIBLE =
+            TagKey.create(Registries.ENCHANTMENT, getResourceLocation("bauble_incompatible"));
+
     public TagEnchantment(PackOutput output, CompletableFuture<HolderLookup.Provider> completableFuture, String modId, @Nullable ExistingFileHelper existingFileHelper) {
         super(output, completableFuture, modId, existingFileHelper);
     }
 
     @Override
     protected void addTags(HolderLookup.Provider pProvider) {
+        this.tag(BAUBLE_INCOMPATIBLE).add(Enchantments.MENDING);
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/datagen/tag/TagItem.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/datagen/tag/TagItem.java
@@ -32,6 +32,17 @@ public class TagItem extends ItemTagsProvider {
         this.tag(GOHEI_ENCHANTABLE).add(InitItems.HAKUREI_GOHEI.asItem());
         this.tag(GOHEI_ENCHANTABLE).add(InitItems.SANAE_GOHEI.asItem());
 
+        this.tag(ItemTags.DURABILITY_ENCHANTABLE).add(InitItems.HAKUREI_GOHEI.asItem())
+                .add(InitItems.SANAE_GOHEI.asItem())
+                .add(InitItems.ULTRAMARINE_ORB_ELIXIR.asItem())
+                .add(InitItems.EXPLOSION_PROTECT_BAUBLE.asItem())
+                .add(InitItems.FIRE_PROTECT_BAUBLE.asItem())
+                .add(InitItems.PROJECTILE_PROTECT_BAUBLE.asItem())
+                .add(InitItems.MAGIC_PROTECT_BAUBLE.asItem())
+                .add(InitItems.FALL_PROTECT_BAUBLE.asItem())
+                .add(InitItems.DROWN_PROTECT_BAUBLE.asItem())
+                .add(InitItems.NIMBLE_FABRIC.asItem());
+
         this.tag(MAID_PLANTABLE_SEEDS).addTag(ItemTags.VILLAGER_PLANTABLE_SEEDS);
         this.tag(MAID_PLANTABLE_SEEDS).add(Items.NETHER_WART);
 

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/item/ItemDamageableBauble.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/item/ItemDamageableBauble.java
@@ -1,7 +1,14 @@
 package com.github.tartaricacid.touhoulittlemaid.item;
 
+import com.github.tartaricacid.touhoulittlemaid.datagen.tag.TagEnchantment;
+import net.minecraft.core.Holder;
+import net.minecraft.world.item.EnchantedBookItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
+
+import java.util.Map;
 
 public class ItemDamageableBauble extends Item {
     public ItemDamageableBauble(int durability) {
@@ -12,4 +19,11 @@ public class ItemDamageableBauble extends Item {
     public boolean isFoil(ItemStack stack) {
         return true;
     }
+
+    @Override
+    public boolean supportsEnchantment(ItemStack stack, Holder<Enchantment> enchantment) {
+        // 检查是否含有不兼容附魔, 注册表在 TagEnchantment 中。此处应当仅有mending
+        return super.supportsEnchantment(stack, enchantment) && !enchantment.is(TagEnchantment.BAUBLE_INCOMPATIBLE);
+    }
+
 }


### PR DESCRIPTION

现在可以正确为御币附魔耐久和经验修补，为存在耐久的饰品附魔耐久。